### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Send MQTT, UDP, HTTP messages to Boodskap IoT Platform
 category=Communication
 url=https://boodskap.io/
 architectures=esp8266
+depends=ArduinJson, WiFiManager


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

I did not add the Adafruit DHT library, since it was a dependency of the example sketch, rather than the library itself. However, I think there is an argument for adding that, and I am happy to do so if you prefer.

As for the PubSubClient dependency mentioned in the readme, I didn't find any reference to that library in the code, so I left it off.